### PR TITLE
[FIX] Crash when try to recover bundle identifier with Darwin #40

### DIFF
--- a/x-win-rs/Cargo.toml
+++ b/x-win-rs/Cargo.toml
@@ -39,15 +39,15 @@ windows = { version = "0.58.0", features = [
 png = "0.17.14"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-xcb = { version = "1.4.0" }
+xcb = { version = "1.5.0" }
 x11 = { version = "2.21.0", features = ["xlib"], optional = true }
 zbus = { version = "1.9.2" }
-serde_json = { version = "1.0.128" }
-image = "0.25.2"
+serde_json = { version = "1.0.133" }
+image = "0.25.5"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 cocoa = "0.26.0"
-libc = "0.2.159"
+libc = "0.2.164"
 cocoa-foundation = "0.2.0"
 core-foundation = "0.10.0"
 core-foundation-sys = "0.8.7"

--- a/x-win-rs/src/common/api.rs
+++ b/x-win-rs/src/common/api.rs
@@ -68,3 +68,11 @@ pub fn empty_entity() -> WindowInfo {
     usage: UsageInfo { memory: 0 },
   }
 }
+
+pub fn empty_icon() -> IconInfo {
+  IconInfo {
+    data: String::from(""),
+    height: 0,
+    width: 0,
+  }
+}

--- a/x-win-rs/src/lib.rs
+++ b/x-win-rs/src/lib.rs
@@ -246,7 +246,7 @@ mod tests {
 
   fn test_struct(window_info: WindowInfo) -> Result<(), String> {
     assert_ne!(window_info.id, 0);
-    assert_ne!(window_info.title, "".to_owned());
+    assert_ne!(window_info.title, String::from(""));
     #[cfg(target_os = "linux")]
     assert_eq!(window_info.os, r#"linux"#);
     #[cfg(target_os = "macos")]
@@ -281,7 +281,7 @@ mod tests {
   fn test_empty_entity() -> Result<(), String> {
     let window_info = empty_entity();
     assert_eq!(window_info.id, 0);
-    assert_eq!(window_info.title, "".to_owned());
+    assert_eq!(window_info.title, String::from(""));
     assert_eq!(window_info.os, test_osname());
     Ok(())
   }

--- a/x-win-rs/src/linux/api/wayland_eval_api.rs
+++ b/x-win-rs/src/linux/api/wayland_eval_api.rs
@@ -74,7 +74,7 @@ fn call_script(script: &String) -> String {
   if let Ok((_actor, json)) = response.body::<(bool, String)>() {
     return json;
   }
-  "".to_owned()
+  String::from("")
 }
 
 pub fn get_icon(window_info: &WindowInfo) -> IconInfo {
@@ -99,7 +99,7 @@ get_icon({});
   }
 
   IconInfo {
-    data: "".to_owned(),
+    data: String::from(""),
     height: 0,
     width: 0,
   }

--- a/x-win-rs/src/linux/api/wayland_eval_api.rs
+++ b/x-win-rs/src/linux/api/wayland_eval_api.rs
@@ -1,7 +1,10 @@
 use zbus::Connection;
 
 use crate::{
-  common::x_win_struct::{icon_info::IconInfo, window_info::WindowInfo},
+  common::{
+    api::empty_icon,
+    x_win_struct::{icon_info::IconInfo, window_info::WindowInfo},
+  },
   linux::api::gnome_shell::GNOME_XWIN_EVAL_SCRIPT,
 };
 
@@ -98,9 +101,5 @@ get_icon({});
     }
   }
 
-  IconInfo {
-    data: String::from(""),
-    height: 0,
-    width: 0,
-  }
+  empty_icon()
 }

--- a/x-win-rs/src/linux/api/wayland_extension_api.rs
+++ b/x-win-rs/src/linux/api/wayland_extension_api.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 use super::{
-  common_api::init_entity,
+  common_api::{empty_icon, init_entity},
   gnome_shell::{value_to_icon_info, GNOME_XWIN_GET_ICON_SCRIPT},
 };
 
@@ -57,11 +57,7 @@ pub fn get_icon(window_info: &WindowInfo) -> IconInfo {
       }
     }
   }
-  IconInfo {
-    data: "".to_owned(),
-    width: 0,
-    height: 0,
-  }
+  empty_icon()
 }
 
 pub fn install_extension() -> bool {
@@ -209,7 +205,7 @@ fn call_script(method_name: &str) -> String {
   if let Ok(json) = response.body::<String>() {
     return json;
   }
-  "".to_owned()
+  String::from("")
 }
 
 fn call_script_arg(method_name: &str, body: u32) -> String {
@@ -228,5 +224,5 @@ fn call_script_arg(method_name: &str, body: u32) -> String {
   if let Ok(json) = response.body::<String>() {
     return json;
   }
-  "".to_owned()
+  String::from("")
 }

--- a/x-win-rs/src/linux/api/wayland_extension_api.rs
+++ b/x-win-rs/src/linux/api/wayland_extension_api.rs
@@ -3,7 +3,10 @@ use zbus::Connection;
 use std::{env, fs, io, ops::Deref, path};
 
 use crate::{
-  common::x_win_struct::{icon_info::IconInfo, window_info::WindowInfo},
+  common::{
+    api::empty_icon,
+    x_win_struct::{icon_info::IconInfo, window_info::WindowInfo},
+  },
   linux::api::gnome_shell::{
     value_to_window_info, GNOME45_XWIN_EXTENSION_SCRIPT, GNOME_SINGLETON,
     GNOME_XWIN_EXTENSION_COMMON_SCRIPT, GNOME_XWIN_EXTENSION_FOLDER_PATH,
@@ -12,7 +15,7 @@ use crate::{
 };
 
 use super::{
-  common_api::{empty_icon, init_entity},
+  common_api::init_entity,
   gnome_shell::{value_to_icon_info, GNOME_XWIN_GET_ICON_SCRIPT},
 };
 

--- a/x-win-rs/src/linux/api/x11_api.rs
+++ b/x-win-rs/src/linux/api/x11_api.rs
@@ -7,13 +7,13 @@ use xcb::{x, Connection, Xid, XidNew};
 
 use crate::{
   common::{
-    api::Api,
+    api::{empty_icon, Api},
     x_win_struct::{icon_info::IconInfo, window_info::WindowInfo, window_position::WindowPosition},
   },
   linux::api::common_api::{get_window_memory_usage, get_window_path_name},
 };
 
-use super::common_api::{empty_icon, init_entity};
+use super::common_api::init_entity;
 
 /**
  * Struct to use similar as API to get active window and open windows for XOrg desktop

--- a/x-win-rs/src/linux/api/x11_api.rs
+++ b/x-win-rs/src/linux/api/x11_api.rs
@@ -13,7 +13,7 @@ use crate::{
   linux::api::common_api::{get_window_memory_usage, get_window_path_name},
 };
 
-use super::common_api::init_entity;
+use super::common_api::{empty_icon, init_entity};
 
 /**
  * Struct to use similar as API to get active window and open windows for XOrg desktop
@@ -145,11 +145,7 @@ impl Api for X11Api {
         }
       }
     }
-    IconInfo {
-      data: "".to_owned(),
-      width: 0,
-      height: 0,
-    }
+    empty_icon()
   }
 
   fn get_browser_url(&self, _: &WindowInfo) -> String {
@@ -258,7 +254,7 @@ fn _get_string_response(conn: &xcb::Connection, window: x::Window, property: x::
     let window_title: &[u8] = window_title.value();
     unsafe { std::str::from_utf8_unchecked(window_title).to_string() }
   } else {
-    "".to_owned()
+    String::from("")
   }
 }
 

--- a/x-win-rs/src/macos/api.rs
+++ b/x-win-rs/src/macos/api.rs
@@ -228,7 +228,7 @@ fn get_windows_informations(only_active: bool) -> Vec<WindowInfo> {
 
 fn is_browser_bundle_id(bundle_id: &String) -> bool {
   matches!(
-    bundle_id.to_str(),
+    bundle_id.as_str(),
     "com.apple.Safari"
       | "com.apple.SafariTechnologyPreview"
       | "com.google.Chrome"
@@ -262,7 +262,7 @@ fn is_browser_bundle_id(bundle_id: &String) -> bool {
 
 fn is_from_document(bundle_id: &String) -> bool {
   matches!(
-    bundle_id.to_str(),
+    bundle_id.as_str(),
     "com.apple.Safari" | "com.apple.SafariTechnologyPreview" | "com.kagi.kagimacOS"
   )
 }

--- a/x-win-rs/src/macos/api.rs
+++ b/x-win-rs/src/macos/api.rs
@@ -226,9 +226,9 @@ fn get_windows_informations(only_active: bool) -> Vec<WindowInfo> {
   windows
 }
 
-fn is_browser_bundle_id(bundle_id: &String) -> bool {
+fn is_browser_bundle_id(bundle_id: &str) -> bool {
   matches!(
-    bundle_id.as_str(),
+    bundle_id,
     "com.apple.Safari"
       | "com.apple.SafariTechnologyPreview"
       | "com.google.Chrome"
@@ -260,9 +260,9 @@ fn is_browser_bundle_id(bundle_id: &String) -> bool {
   )
 }
 
-fn is_from_document(bundle_id: &String) -> bool {
+fn is_from_document(bundle_id: &str) -> bool {
   matches!(
-    bundle_id.as_str(),
+    bundle_id,
     "com.apple.Safari" | "com.apple.SafariTechnologyPreview" | "com.kagi.kagimacOS"
   )
 }

--- a/x-win-rs/src/win32/api.rs
+++ b/x-win-rs/src/win32/api.rs
@@ -18,7 +18,7 @@ use windows::{
 };
 
 use crate::common::{
-  api::{empty_entity, os_name, Api},
+  api::{empty_entity, empty_icon, os_name, Api},
   x_win_struct::{
     icon_info::IconInfo, process_info::ProcessInfo, usage_info::UsageInfo, window_info::WindowInfo,
     window_position::WindowPosition,
@@ -205,15 +205,11 @@ impl Api for WindowsAPI {
       }
     }
 
-    IconInfo {
-      data: "".to_owned(),
-      height: 0,
-      width: 0,
-    }
+    empty_icon()
   }
 
   fn get_browser_url(&self, window_info: &WindowInfo) -> String {
-    let mut url: String = "".to_owned();
+    let mut url: String = String::from("");
     if window_info.info.exec_name.ne(&"") && is_browser(window_info.info.exec_name.as_str()) {
       let hwnd = unsafe {
         let data: Vec<u16> = OsStr::new(&window_info.title.to_owned())
@@ -663,7 +659,7 @@ fn get_url_for_chromium_from_ctrlk(
     }
   }
 
-  "".to_owned()
+  String::from("")
 }
 
 fn is_browser(browser_name: &str) -> bool {


### PR DESCRIPTION
## Issue
* #40 Crash with Tauri doe to a bundle identifier empty when running in dev environment
* Fix wrong exec name value for darwin

## Change
* Set IconInfo from a function to simplify any change
* Update deps. versions
