### PR TITLE
[FEAT] Add functions to ask or check screen record permission for MacOS system

### DIFF
--- a/.github/workflows/ci-napi.yml
+++ b/.github/workflows/ci-napi.yml
@@ -163,7 +163,7 @@ jobs:
 
       # Check clippy code
       - name: Check clippy code
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --all-features -- -D warnings
 
       # Build the project
       - name: Build

--- a/.github/workflows/ci-rs.yml
+++ b/.github/workflows/ci-rs.yml
@@ -100,7 +100,7 @@ jobs:
 
       # Check clippy code
       - name: Clippy
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --all-features -- -D warnings
 
       - name: Open finder to have an active window (MacOS)
         if: ${{ matrix.settings.host == 'macos-latest' }}

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,3 @@
-cd x-win-rs && cargo fmt -- --check && cargo clippy -- -D warnings && cargo test
+cd x-win-rs && cargo fmt -- --check && cargo clippy --all-features -- -D warnings && cargo test
 cd ..
-cargo fmt -- --check
-cargo clippy -- -D warnings
-yarn test
+cargo fmt -- --check && cargo clippy --all-features -- -D warnings && yarn test

--- a/x-win-rs/Cargo.toml
+++ b/x-win-rs/Cargo.toml
@@ -12,6 +12,10 @@ license = "MIT"
 name = "x_win"
 path = "src/lib.rs"
 
+[features]
+default = []
+macos_permission = []
+
 [dependencies]
 once_cell = "1.20.2"
 base64 = "0.22.1"
@@ -46,13 +50,14 @@ serde_json = { version = "1.0.133" }
 image = "0.25.5"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-cocoa = "0.26.0"
-libc = "0.2.164"
-cocoa-foundation = "0.2.0"
+libc = "0.2.166"
 core-foundation = "0.10.0"
 core-foundation-sys = "0.8.7"
 core-graphics = "0.24.0"
-objc = "0.2.7"
+objc2 = { version = "0.5.2" }
+objc2-foundation = { version = "0.2.2", features = ["NSArray", "NSString", "NSGeometry", "NSProcessInfo"] }
+objc2-app-kit = { version = "0.2.2", features = ["NSImage", "NSRunningApplication", "NSWorkspace", "NSBitmapImageRep", "NSImageRep", "NSScreen"] }
+block2 = "0.5.1"
 
 [profile.release]
 lto = true

--- a/x-win-rs/src/lib.rs
+++ b/x-win-rs/src/lib.rs
@@ -29,6 +29,9 @@ use linux::init_platform_api;
 use macos::init_platform_api;
 
 #[cfg(all(feature = "macos_permission", target_os = "macos"))]
+/// Handle screen record permission
+/// <div class="warning">important Work only with macOS 10.15+</div>
+/// To use this function you need to add `macos_permission` feature
 pub use macos::permission;
 
 pub use common::{

--- a/x-win-rs/src/lib.rs
+++ b/x-win-rs/src/lib.rs
@@ -1,10 +1,8 @@
 #![deny(unsafe_op_in_unsafe_fn)]
-//#![deny(clippy::all)]
-//#![allow(unused_imports)]
 
 #[cfg(target_os = "macos")]
 #[macro_use]
-extern crate objc;
+extern crate objc2;
 
 #[cfg(target_os = "macos")]
 #[macro_use]
@@ -29,6 +27,9 @@ use linux::init_platform_api;
 
 #[cfg(target_os = "macos")]
 use macos::init_platform_api;
+
+#[cfg(all(feature = "macos_permission", target_os = "macos"))]
+pub use macos::permission;
 
 pub use common::{
   api::{empty_entity, os_name},
@@ -333,6 +334,26 @@ mod tests {
     let window_info = &get_active_window().unwrap().to_owned();
     let url = get_browser_url(&window_info).unwrap();
     assert!(url.eq("URL recovery not supported on Linux distribution!"));
+    Ok(())
+  }
+
+  #[cfg(all(feature = "macos_permission", target_os = "macos"))]
+  #[test]
+  #[ignore = "Not working on ci/cd"]
+  fn test_check_screen_record_permission() -> Result<(), String> {
+    use macos::permission::check_screen_record_permission;
+    let value = check_screen_record_permission();
+    assert_eq!(value, true);
+    Ok(())
+  }
+
+  #[cfg(all(feature = "macos_permission", target_os = "macos"))]
+  #[test]
+  #[ignore = "Not working on ci/cd"]
+  fn test_request_screen_record_permission() -> Result<(), String> {
+    use macos::permission::request_screen_record_permission;
+    let value = request_screen_record_permission();
+    assert_eq!(value, true);
     Ok(())
   }
 }

--- a/x-win-rs/src/lib.rs
+++ b/x-win-rs/src/lib.rs
@@ -189,14 +189,8 @@ mod tests {
       println!(
         "[START] Command Status: {:?}; Command stdout: {:?}; Command stderr: {:?}",
         output.status,
-        (match std::str::from_utf8(&output.stdout) {
-          Ok(val) => val,
-          Err(_) => "Error when convert output",
-        }),
-        (match std::str::from_utf8(&output.stderr) {
-          Ok(val) => val,
-          Err(_) => "Error when convert output",
-        })
+        std::str::from_utf8(&output.stdout).unwrap_or("Error when convert output"),
+        std::str::from_utf8(&output.stderr).unwrap_or("Error when convert stderr")
       );
       thread::sleep(time::Duration::from_secs(3));
       TestContext
@@ -220,14 +214,8 @@ mod tests {
       println!(
         "[DONE] Command Status: {:?}; Command stdout: {:?}; Command stderr: {:?}",
         output.status,
-        (match std::str::from_utf8(&output.stdout) {
-          Ok(val) => val,
-          Err(_) => "Error when convert output",
-        }),
-        (match std::str::from_utf8(&output.stderr) {
-          Ok(val) => val,
-          Err(_) => "Error when convert output",
-        })
+        std::str::from_utf8(&output.stdout).unwrap_or("Error when convert output"),
+        std::str::from_utf8(&output.stderr).unwrap_or("Error when convert stderr")
       );
       thread::sleep(time::Duration::from_secs(3));
     }
@@ -293,7 +281,7 @@ mod tests {
   #[test]
   fn test_get_window_icon() -> Result<(), String> {
     let window_info: &WindowInfo = &get_active_window().unwrap();
-    let icon_info = get_window_icon(&window_info).unwrap();
+    let icon_info = get_window_icon(window_info).unwrap();
     assert_ne!(icon_info.data, "");
     assert_ne!(icon_info.height, 0);
     assert_ne!(icon_info.width, 0);
@@ -320,7 +308,7 @@ mod tests {
     println!("URL: {:?}; process: {:?}", url, window_info.info.name);
     assert!(url.starts_with("http"));
     let window_info = &get_active_window().unwrap().to_owned();
-    let url = get_browser_url(&window_info).unwrap();
+    let url = get_browser_url(window_info).unwrap();
     println!("URL: {:?}; process: {:?}", url, window_info.info.name);
     assert!(url.starts_with("http"));
     Ok(())

--- a/x-win-rs/src/linux/api/wayland_eval_api.rs
+++ b/x-win-rs/src/linux/api/wayland_eval_api.rs
@@ -24,7 +24,7 @@ get_active_window();
 
   let response = call_script(&script);
 
-  if response.ne(&"") {
+  if !response.is_empty() {
     let response: serde_json::Value = serde_json::from_str(response.as_str()).unwrap();
     if response.is_object() {
       return value_to_window_info(&response);

--- a/x-win-rs/src/linux/api/wayland_extension_api.rs
+++ b/x-win-rs/src/linux/api/wayland_extension_api.rs
@@ -22,7 +22,7 @@ use super::{
 pub fn get_active_window() -> WindowInfo {
   let response = call_script("get_active_window");
 
-  if response.ne(&"") {
+  if !response.is_empty() {
     let response: serde_json::Value = serde_json::from_str(response.as_str()).unwrap();
     if response.is_object() {
       return value_to_window_info(&response);
@@ -34,7 +34,7 @@ pub fn get_active_window() -> WindowInfo {
 
 pub fn get_open_windows() -> Vec<WindowInfo> {
   let response = call_script("get_open_windows");
-  if response.ne(&"") {
+  if !response.is_empty() {
     let response: serde_json::Value = serde_json::from_str(response.as_str()).unwrap();
 
     if response.is_array() {
@@ -53,7 +53,7 @@ pub fn get_open_windows() -> Vec<WindowInfo> {
 pub fn get_icon(window_info: &WindowInfo) -> IconInfo {
   if window_info.id.ne(&0) {
     let response = call_script_arg("get_icon", window_info.id);
-    if response.ne(&"") {
+    if !response.empty() {
       let response: serde_json::Value = serde_json::from_str(response.as_str()).unwrap();
       if response.is_object() {
         return value_to_icon_info(&response);

--- a/x-win-rs/src/linux/api/wayland_extension_api.rs
+++ b/x-win-rs/src/linux/api/wayland_extension_api.rs
@@ -53,7 +53,7 @@ pub fn get_open_windows() -> Vec<WindowInfo> {
 pub fn get_icon(window_info: &WindowInfo) -> IconInfo {
   if window_info.id.ne(&0) {
     let response = call_script_arg("get_icon", window_info.id);
-    if !response.empty() {
+    if !response.is_empty() {
       let response: serde_json::Value = serde_json::from_str(response.as_str()).unwrap();
       if response.is_object() {
         return value_to_icon_info(&response);

--- a/x-win-rs/src/macos/api.rs
+++ b/x-win-rs/src/macos/api.rs
@@ -73,7 +73,7 @@ impl Api for MacosAPI {
   }
 
   fn get_app_icon(&self, window_info: &WindowInfo) -> IconInfo {
-    if window_info.info.path.ne("") {
+    if !window_info.info.path.is_empty() {
       let path: &NSString = &NSString::from_str(&window_info.info.path);
 
       let nsimage: &NSImage = unsafe { &NSWorkspace::sharedWorkspace().iconForFile(path) };

--- a/x-win-rs/src/macos/api.rs
+++ b/x-win-rs/src/macos/api.rs
@@ -1,24 +1,31 @@
 #![deny(unused_imports)]
 
 use std::process::Command;
+use std::ptr::null_mut;
 
+use base64::prelude::BASE64_STANDARD;
 use base64::Engine;
-use cocoa::appkit::NSScreen;
-use cocoa::base::{id, nil};
-use cocoa::foundation::{NSRect, NSString, NSURL};
+use libc::pid_t;
+use objc2::rc::Retained;
+use objc2::{ClassType, Encode, RefEncode};
+use objc2_app_kit::{
+  NSBitmapImageFileType, NSBitmapImageRep, NSImage, NSRunningApplication, NSScreen, NSWorkspace,
+};
+use objc2_foundation::{
+  CGPoint, CGRect, CGSize, MainThreadMarker, NSDictionary, NSObject, NSRect, NSString,
+};
+
 use core_foundation::array::{CFArrayGetCount, CFArrayGetValueAtIndex};
 use core_foundation::base::{CFType, TCFType};
 use core_foundation::boolean::CFBoolean;
-
 use core_foundation::dictionary::{CFDictionary, CFDictionaryRef};
-
 use core_foundation::number::CFNumber;
 use core_foundation::string::CFString;
 use core_graphics::display::{
   kCGWindowListExcludeDesktopElements, kCGWindowListOptionIncludingWindow,
   kCGWindowListOptionOnScreenOnly, CGWindowListCopyWindowInfo,
 };
-use core_graphics::geometry::CGRect;
+use core_graphics::geometry::CGRect as GeCGRect;
 use core_graphics::window::{
   kCGWindowBounds, kCGWindowIsOnscreen, kCGWindowLayer, kCGWindowMemoryUsage, kCGWindowName,
   kCGWindowNumber, kCGWindowOwnerName, kCGWindowOwnerPID,
@@ -33,9 +40,19 @@ use crate::common::{
   },
 };
 
-use objc::runtime::{BOOL, NO};
-
 pub struct MacosAPI {}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct CGImage {}
+
+unsafe impl Encode for CGImage {
+  const ENCODING: objc2::Encoding = objc2::Encoding::Struct("CGImage", &[]);
+}
+
+unsafe impl RefEncode for CGImage {
+  const ENCODING_REF: objc2::Encoding = objc2::Encoding::Pointer(&Self::ENCODING);
+}
 
 /**
  * Impl. for Darwin system
@@ -57,32 +74,38 @@ impl Api for MacosAPI {
 
   fn get_app_icon(&self, window_info: &WindowInfo) -> IconInfo {
     if window_info.info.path.ne("") {
-      unsafe {
-        let path = NSString::alloc(nil).init_str(&window_info.info.path);
-        let nsworkspace: id = msg_send![class!(NSWorkspace), sharedWorkspace];
-        let nsimage: id = msg_send![nsworkspace, iconForFile: path];
+      let path: &NSString = &NSString::from_str(&window_info.info.path);
 
-        if !nsimage.is_null() {
-          let cgref: id = msg_send![
-            nsimage,
-            CGImageForProposedRect: nil
-            context: nil
-            hints: nil
-          ];
-          let nsbitmapref: id = msg_send![class!(NSBitmapImageRep), alloc];
-          let imagerep: id = msg_send![nsbitmapref, initWithCGImage: cgref];
-          let imagesize: (f64, f64) = msg_send![nsimage, size];
-          let _: () = msg_send![imagerep, setSize: imagesize];
-          let pngdata: id = msg_send![imagerep, representationUsingType:4 properties:nil];
-          let length: usize = msg_send![pngdata, length];
-          let bytes: *const u8 = msg_send![pngdata, bytes];
-          let byte_slice: &[u8] = std::slice::from_raw_parts(bytes, length);
-          let data = base64::prelude::BASE64_STANDARD.encode(byte_slice);
-          return IconInfo {
-            data: format!("data:image/png;base64,{}", data),
-            width: imagesize.0 as u32,
-            height: imagesize.1 as u32,
-          };
+      let nsimage: &NSImage = unsafe { &NSWorkspace::sharedWorkspace().iconForFile(path) };
+      if unsafe { nsimage.isValid() } {
+        let imagesize = unsafe { nsimage.size() };
+        let rect: &CGRect = &CGRect::new(CGPoint::new(0.0, 0.0), CGSize::new(0.0, 0.0));
+        let cgref: &CGImage = unsafe {
+          msg_send![nsimage, CGImageForProposedRect: rect context: null_mut::<NSObject>() hints: null_mut::<NSObject>()]
+        };
+
+        let nsbitmapref = NSBitmapImageRep::alloc();
+        let imagerep: Retained<NSBitmapImageRep> =
+          unsafe { msg_send_id![nsbitmapref, initWithCGImage: cgref] };
+        let _ = unsafe { imagerep.setSize(imagesize) };
+        let pngdata = unsafe {
+          imagerep
+            .representationUsingType_properties(NSBitmapImageFileType::PNG, &NSDictionary::new())
+        };
+        match pngdata {
+          Some(pngdata) => {
+            let bytes = pngdata.bytes();
+            let data = BASE64_STANDARD.encode(bytes);
+            let t = IconInfo {
+              data: format!("data:image/png;base64,{}", data),
+              width: imagesize.width as u32,
+              height: imagesize.height as u32,
+            };
+            return t;
+          }
+          None => {
+            return empty_icon();
+          }
         }
       }
     }
@@ -129,30 +152,25 @@ fn get_windows_informations(only_active: bool) -> Vec<WindowInfo> {
 
     let bounds = cfd.get(unsafe { kCGWindowBounds });
     let bounds: CFDictionary = bounds.downcast::<CFDictionary>().unwrap();
-    let bounds = CGRect::from_dict_representation(&bounds.to_untyped());
+    let bounds = GeCGRect::from_dict_representation(&bounds.to_untyped());
     if bounds.is_none() {
       continue;
     }
 
-    let bounds: CGRect = bounds.unwrap();
+    let bounds: GeCGRect = bounds.unwrap();
     if bounds.size.height.lt(&50.0) || bounds.size.width.lt(&50.0) {
       continue;
     }
-
     let process_id = cfd.get(unsafe { kCGWindowOwnerPID });
     let process_id = process_id.downcast::<CFNumber>().unwrap().to_i64().unwrap();
-
-    let app: id = unsafe {
+    let app: &NSRunningApplication = unsafe {
       msg_send![
         class!(NSRunningApplication),
-        runningApplicationWithProcessIdentifier: process_id
+        runningApplicationWithProcessIdentifier: pid_t::from(process_id as i32)
       ]
     };
 
-    let is_not_active: bool = unsafe {
-      let is_active: BOOL = msg_send![app, isActive];
-      is_active == NO
-    };
+    let is_not_active = !unsafe { app.isActive() };
 
     if only_active && is_not_active {
       continue;
@@ -179,16 +197,28 @@ fn get_windows_informations(only_active: bool) -> Vec<WindowInfo> {
       title = title_ref.downcast::<CFString>().unwrap().to_string();
     }
 
-    let bundle_url: id = unsafe { msg_send![app, bundleURL] };
-    let path = unsafe { bundle_url.path().UTF8String() };
-    let path = std::str::from_utf8(unsafe { std::ffi::CStr::from_ptr(path).to_bytes() }).unwrap();
+    let path: String = unsafe {
+      match app.bundleURL() {
+        Some(nsurl) => match nsurl.path() {
+          Some(path) => path.to_string(),
+          None => String::from(""),
+        },
+        None => String::from(""),
+      }
+    };
 
-    let exec_name: String = std::path::Path::new(&path)
-      .file_name()
-      .unwrap()
-      .to_str()
-      .unwrap_or("")
-      .to_owned();
+    let exec_name: String = {
+      match path.is_empty() {
+        true => match std::path::Path::new(&path).file_name() {
+          Some(os_str) => match os_str.to_str() {
+            Some(exec_name) => exec_name.to_owned(),
+            None => String::from(""),
+          },
+          None => String::from(""),
+        },
+        false => String::from(""),
+      }
+    };
 
     let memory = cfd.get(unsafe { kCGWindowMemoryUsage });
     let memory = memory.downcast::<CFNumber>().unwrap().to_i64().unwrap();
@@ -284,11 +314,14 @@ fn execute_applescript(script: &str) -> String {
 }
 
 fn get_screen_rect() -> NSRect {
-  let screen = unsafe { NSScreen::mainScreen(nil) };
-  unsafe { NSScreen::frame(screen) }
+  if let Some(screen) = unsafe { NSScreen::mainScreen(MainThreadMarker::new_unchecked()) } {
+    return screen.frame();
+  } else {
+    return NSRect::new(CGPoint::new(0.0, 0.0), CGSize::new(0.0, 0.0));
+  }
 }
 
-fn is_full_screen(window_rect: CGRect, screen_rect: NSRect) -> bool {
+fn is_full_screen(window_rect: GeCGRect, screen_rect: NSRect) -> bool {
   window_rect.size.height.eq(&screen_rect.size.height)
     && window_rect.size.width.eq(&screen_rect.size.width)
     && window_rect.origin.y.eq(&screen_rect.origin.y)
@@ -297,12 +330,14 @@ fn is_full_screen(window_rect: CGRect, screen_rect: NSRect) -> bool {
 
 fn get_browser_url(process_id: u32) -> String {
   let process_id = process_id as i64;
-  let app: id = unsafe {
+  let app: &NSRunningApplication = unsafe {
     msg_send![
       class!(NSRunningApplication),
-      runningApplicationWithProcessIdentifier: process_id
+      runningApplicationWithProcessIdentifier: pid_t::from(process_id as i32)
     ]
   };
+
+  println!("app: {:?}", app);
 
   let bundle_identifier = get_bundle_identifier(app);
   if bundle_identifier.is_empty() {
@@ -330,19 +365,11 @@ fn get_browser_url(process_id: u32) -> String {
   }
 }
 
-fn get_bundle_identifier(app: id) -> String {
-  if !app.is_null() {
-    unsafe {
-      let bundle_identifier: id = msg_send![app, bundleIdentifier];
-      let bundle_identifier = NSString::UTF8String(bundle_identifier);
-      if !bundle_identifier.is_null() {
-        return std::str::from_utf8(std::ffi::CStr::from_ptr(bundle_identifier).to_bytes())
-          .unwrap_or("")
-          .to_string();
-      } else {
-        return String::from("");
-      }
+fn get_bundle_identifier(app: &NSRunningApplication) -> String {
+  unsafe {
+    match app.bundleIdentifier() {
+      Some(bundle_identifier) => bundle_identifier.to_string(),
+      None => return String::from(""),
     }
   }
-  String::from("")
 }

--- a/x-win-rs/src/macos/api.rs
+++ b/x-win-rs/src/macos/api.rs
@@ -87,7 +87,7 @@ impl Api for MacosAPI {
         let nsbitmapref = NSBitmapImageRep::alloc();
         let imagerep: Retained<NSBitmapImageRep> =
           unsafe { msg_send_id![nsbitmapref, initWithCGImage: cgref] };
-        let _ = unsafe { imagerep.setSize(imagesize) };
+        let _: () = unsafe { imagerep.setSize(imagesize) };
         let pngdata = unsafe {
           imagerep
             .representationUsingType_properties(NSBitmapImageFileType::PNG, &NSDictionary::new())
@@ -308,16 +308,17 @@ fn is_from_document(bundle_id: &str) -> bool {
 fn execute_applescript(script: &str) -> String {
   let output = Command::new("osascript").args(["-e", script]).output();
   if let Ok(output) = output {
-    return String::from_utf8_lossy(&output.stdout).trim().to_owned();
+    String::from_utf8_lossy(&output.stdout).trim().to_owned()
+  } else {
+    "".into()
   }
-  "".into()
 }
 
 fn get_screen_rect() -> NSRect {
   if let Some(screen) = unsafe { NSScreen::mainScreen(MainThreadMarker::new_unchecked()) } {
-    return screen.frame();
+    screen.frame()
   } else {
-    return NSRect::new(CGPoint::new(0.0, 0.0), CGSize::new(0.0, 0.0));
+    NSRect::new(CGPoint::new(0.0, 0.0), CGSize::new(0.0, 0.0))
   }
 }
 
@@ -336,8 +337,6 @@ fn get_browser_url(process_id: u32) -> String {
       runningApplicationWithProcessIdentifier: pid_t::from(process_id as i32)
     ]
   };
-
-  println!("app: {:?}", app);
 
   let bundle_identifier = get_bundle_identifier(app);
   if bundle_identifier.is_empty() {
@@ -369,7 +368,7 @@ fn get_bundle_identifier(app: &NSRunningApplication) -> String {
   unsafe {
     match app.bundleIdentifier() {
       Some(bundle_identifier) => bundle_identifier.to_string(),
-      None => return String::from(""),
+      None => String::from(""),
     }
   }
 }

--- a/x-win-rs/src/macos/mod.rs
+++ b/x-win-rs/src/macos/mod.rs
@@ -1,6 +1,7 @@
 #![deny(unused_imports)]
 
 mod api;
+pub mod permission;
 
 use crate::common::api::Api;
 use api::MacosAPI;

--- a/x-win-rs/src/macos/permission.rs
+++ b/x-win-rs/src/macos/permission.rs
@@ -15,10 +15,15 @@ extern "C" {
   fn CGPreflightScreenCaptureAccess() -> BOOL;
 }
 
+/// Return `true` or `false` about screen record permission
+/// <div class="warning">important Work only with macOS 10.15+</div>
+/// To use this function you need to add `macos_permission` feature
 pub fn check_screen_record_permission() -> bool {
   unsafe { CGPreflightScreenCaptureAccess() == YES }
 }
 
+/// Ask for screen record permission and return `true` or `false` after confirmation
+/// <div class="warning">important Work only with macOS 10.15+</div>
 pub fn request_screen_record_permission() -> bool {
   unsafe { CGRequestScreenCaptureAccess() == YES }
 }

--- a/x-win-rs/src/macos/permission.rs
+++ b/x-win-rs/src/macos/permission.rs
@@ -1,0 +1,24 @@
+#![deny(unused_imports)]
+#![allow(dead_code)]
+
+use objc2::ffi::{BOOL, YES};
+
+#[link(name = "CoreGraphics", kind = "framework")]
+extern "C" {
+  #[link_name = "CGRequestScreenCaptureAccess"]
+  fn CGRequestScreenCaptureAccess() -> BOOL;
+}
+
+#[link(name = "CoreGraphics", kind = "framework")]
+extern "C" {
+  #[link_name = "CGPreflightScreenCaptureAccess"]
+  fn CGPreflightScreenCaptureAccess() -> BOOL;
+}
+
+pub fn check_screen_record_permission() -> bool {
+  unsafe { CGPreflightScreenCaptureAccess() == YES }
+}
+
+pub fn request_screen_record_permission() -> bool {
+  unsafe { CGRequestScreenCaptureAccess() == YES }
+}

--- a/x-win-rs/src/win32/api.rs
+++ b/x-win-rs/src/win32/api.rs
@@ -85,7 +85,7 @@ impl Api for WindowsAPI {
 
     enum_desktop_windows(|hwnd| {
       let window_info = get_window_information(hwnd);
-      if !(window_info.title.eq(&"") && window_info.info.exec_name.to_lowercase().eq(&"explorer")) {
+      if !(window_info.title.is_empty() && window_info.info.exec_name.to_lowercase().eq(&"explorer")) {
         results.push(window_info);
       }
       true
@@ -95,7 +95,7 @@ impl Api for WindowsAPI {
   }
 
   fn get_app_icon(&self, window_info: &WindowInfo) -> IconInfo {
-    if window_info.info.path.ne("") {
+    if !window_info.info.path.is_empty() {
       let lpszfile: Vec<u16> = std::path::Path::new(&window_info.info.path)
         .as_os_str()
         .encode_wide()
@@ -210,7 +210,7 @@ impl Api for WindowsAPI {
 
   fn get_browser_url(&self, window_info: &WindowInfo) -> String {
     let mut url: String = String::from("");
-    if window_info.info.exec_name.ne(&"") && is_browser(window_info.info.exec_name.as_str()) {
+    if !window_info.info.exec_name.is_empty() && is_browser(window_info.info.exec_name.as_str()) {
       let hwnd = unsafe {
         let data: Vec<u16> = OsStr::new(&window_info.title.to_owned())
           .encode_wide()
@@ -559,7 +559,7 @@ fn get_browser_url(hwnd: HWND, exec_name: String) -> String {
             x if x.contains("msedge") => {
               let mut value =
                 get_url_from_automation_id(&automation, &element, "view_1022".to_owned());
-              if value.eq(&"") {
+              if value.is_empty() {
                 value = get_url_from_automation_id(&automation, &element, "view_1020".to_owned());
               }
               value.to_owned()

--- a/x-win-rs/src/win32/api.rs
+++ b/x-win-rs/src/win32/api.rs
@@ -85,7 +85,9 @@ impl Api for WindowsAPI {
 
     enum_desktop_windows(|hwnd| {
       let window_info = get_window_information(hwnd);
-      if !(window_info.title.is_empty() && window_info.info.exec_name.to_lowercase().eq(&"explorer")) {
+      if !(window_info.title.is_empty()
+        && window_info.info.exec_name.to_lowercase().eq(&"explorer"))
+      {
         results.push(window_info);
       }
       true


### PR DESCRIPTION
# Rust Part

## Feature

* Add 2 functions `request_screen_record_permission` and `check_screen_record_permission` available only with features `macos_permission`. Work only for macos >= 10.15.

## Change

* Replace `objc` by `objc2`