### PR TITLE
a dangling pointer will be produced because the temporary `Vec<u16>` will be dropped

### DIFF
--- a/x-win-rs/src/win32/api.rs
+++ b/x-win-rs/src/win32/api.rs
@@ -431,11 +431,11 @@ fn get_process_name_from_path(process_path: &Path) -> Result<String, ()> {
     lang.w_language, lang.w_code_page
   );
   let lang_code_string: String = lang_code.to_string();
-  let lang_code_ptr: *const u16 = lang_code_string
+  let lang_code_vec = lang_code_string
     .encode_utf16()
     .chain(Some(0))
-    .collect::<Vec<_>>()
-    .as_ptr();
+    .collect::<Vec<_>>();
+  let lang_code_ptr: *const u16 = lang_code_vec.as_ptr();
 
   let lang_code: PCWSTR = PCWSTR::from_raw(lang_code_ptr);
 


### PR DESCRIPTION


warning: a dangling pointer will be produced because the temporary `Vec<u16>` will be dropped
   --> x-win-rs\src\win32\api.rs:438:6
    |
434 |     let lang_code_ptr: *const u16 = lang_code_string
    |  ___________________________________-
435 | |     .encode_utf16()
436 | |     .chain(Some(0))
437 | |     .collect::<Vec<_>>()
    | |________________________- this `Vec<u16>` is deallocated at the end of the statement, bind it to a variable to extend its lifetime
438 |       .as_ptr();
    |        ^^^^^^ this pointer will immediately be invalid
    |
    = note: pointers do not have a lifetime; when calling `as_ptr` the `Vec<u16>` will be deallocated at the end of the statement because nothing is referencing it as far as the type system is concerned
    = help: for more information, see <https://doc.rust-lang.org/reference/destructors.html>
    = note: `#[warn(dangling_pointers_from_temporaries)]` on by default