### PR TITLE
Fix issue #53 Crash with X11 with alt+tab switch screen

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -342,6 +342,7 @@ pub fn subscribe_active_window(callback: JsFunction, interval: Option<JsNumber>)
 
   let id = thread_manager.start_thread(move |receiver| {
     let mut current_window: WindowInfo = empty_entity().into();
+    let mut first_loop: bool = true;
     loop {
       match receiver.try_recv() {
         Ok(_) | Err(std::sync::mpsc::TryRecvError::Disconnected) => {
@@ -355,7 +356,7 @@ pub fn subscribe_active_window(callback: JsFunction, interval: Option<JsNumber>)
               .info
               .process_id
               .ne(&current_window.info.process_id)
-            || new_current_window.id.eq(&0)
+            || (new_current_window.id.eq(&0) && first_loop)
           {
             current_window = new_current_window.clone().into();
             tsfn_clone.call(
@@ -365,6 +366,9 @@ pub fn subscribe_active_window(callback: JsFunction, interval: Option<JsNumber>)
           }
           thread::sleep(Duration::from_millis(interval));
         }
+      }
+      if first_loop {
+        first_loop = false;
       }
     }
   });

--- a/x-win-rs/src/linux/api/x11_api.rs
+++ b/x-win-rs/src/linux/api/x11_api.rs
@@ -90,14 +90,10 @@ impl Api for X11Api {
             if window_list.len().ne(&0) {
               for window in window_list {
                 let window: &x::Window = &window;
-
-                match get_window_information(&conn, window) {
-                  Ok(result) => {
-                    if result.id.ne(&0) && is_normal_window(&conn, *window) {
-                      results.push(result);
-                    }
+                if let Ok(result) = get_window_information(&conn, window) {
+                  if result.id.ne(&0) && is_normal_window(&conn, *window) {
+                    results.push(result);
                   }
-                  Err(_) => {}
                 }
               }
             }

--- a/x-win-rs/src/linux/api/x11_api.rs
+++ b/x-win-rs/src/linux/api/x11_api.rs
@@ -11,6 +11,7 @@ use crate::{
     result::Result,
     x_win_struct::{icon_info::IconInfo, window_info::WindowInfo, window_position::WindowPosition},
   },
+  empty_entity,
   linux::api::common_api::{get_window_memory_usage, get_window_path_name},
 };
 
@@ -47,13 +48,20 @@ impl Api for X11Api {
                 let active_window = get_window_information(&conn, active_window)?;
                 Ok(active_window)
               }
-              None => Err(String::from("").into()),
+              None => Ok(empty_entity()),
             };
           }
         }
-        Err(String::from("").into())
+        Err(
+          String::from(
+            "Something got wrong, not possible to get active window calling _NET_ACTIVE_WINDOW",
+          )
+          .into(),
+        )
       }
-      None => Err(String::from("").into()),
+      None => {
+        Err(String::from("Something got wrong, not possible to get access of X Server!").into())
+      }
     }
   }
 
@@ -82,9 +90,14 @@ impl Api for X11Api {
             if window_list.len().ne(&0) {
               for window in window_list {
                 let window: &x::Window = &window;
-                let result = get_window_information(&conn, window)?;
-                if result.id.ne(&0) && is_normal_window(&conn, *window) {
-                  results.push(result);
+
+                match get_window_information(&conn, window) {
+                  Ok(result) => {
+                    if result.id.ne(&0) && is_normal_window(&conn, *window) {
+                      results.push(result);
+                    }
+                  }
+                  Err(_) => {}
                 }
               }
             }
@@ -92,9 +105,11 @@ impl Api for X11Api {
             return Ok(results);
           }
         }
-        Err(String::from("").into())
+        Err(String::from("Something got wrong, not possible to get active window calling _NET_CLIENT_LIST_STACKING").into())
       }
-      None => Err(String::from("").into()),
+      None => {
+        Err(String::from("Something got wrong, not possible to get access of X Server!").into())
+      }
     }
   }
 
@@ -169,9 +184,11 @@ fn connection() -> Result<Connection> {
  * Get window information
  */
 fn get_window_information(conn: &xcb::Connection, window: &x::Window) -> Result<WindowInfo> {
-  let window_pid: u32 = get_window_pid(conn, *window)?;
   let mut window_info: WindowInfo = init_entity();
-
+  if window.is_none() {
+    return Ok(window_info);
+  }
+  let window_pid: u32 = get_window_pid(conn, *window)?;
   if window_pid != 0 {
     let (path, exec_name) = get_window_path_name(window_pid)?;
     window_info.id = window.resource_id();
@@ -209,7 +226,7 @@ fn get_window_pid(conn: &xcb::Connection, window: x::Window) -> Result<u32> {
       }
     }
   }
-  Err(String::from("").into())
+  Err(String::from("Not possible to recver pid for the window when calling _NET_WM_PID!").into())
 }
 
 /**


### PR DESCRIPTION
# Fix issue
* Problem with Ubuntu when using X11 Desktop and switching window throw `alt`+`tab` who generate an empty screen value and generate an error when trying to recover PID of it
* Add message to prevent of empty Error message when it append
* Add a pointer for node part when calling `subscribe_active_window` to avoid flooding with empty `WindowInfo` with window tab screen