### PR TITLE
Fix memory leak on macOS: wrap window enumeration in autorelease pool

### DIFF
--- a/x-win-rs/src/macos/api.rs
+++ b/x-win-rs/src/macos/api.rs
@@ -112,6 +112,10 @@ impl Api for MacosAPI {
 }
 
 fn get_windows_informations(only_active: bool) -> Result<Vec<WindowInfo>> {
+  objc2::rc::autoreleasepool(|_pool| get_windows_informations_inner(only_active))
+}
+
+fn get_windows_informations_inner(only_active: bool) -> Result<Vec<WindowInfo>> {
   let mut windows: Vec<WindowInfo> = Vec::new();
 
   let option = CGWindowListOption::OptionOnScreenOnly


### PR DESCRIPTION
Without an explicit autorelease pool, autoreleased objects accumulate until the enclosing pool drains. On background threads, this means objects accumulate until thread exit—effectively forever in long-running applications.

Per Apple's [memory management docs](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/MemoryMgmt/Articles/mmAutoreleasePools.html): "If you spawn a secondary thread... you must create your own autorelease pool block as soon as the thread begins executing; otherwise, your application will leak objects."