### PR TITLE
fix(linux): Issues #89 #90 #91 Correction wrong function called  + fix missing attribute for empty info + rework data convert

### DIFF
--- a/x-win-rs/src/common/x_win_struct/icon_info.rs
+++ b/x-win-rs/src/common/x_win_struct/icon_info.rs
@@ -3,7 +3,7 @@
 /**
  * Struct to store Icon information
  */
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, PartialOrd)]
 #[repr(C)]
 pub struct IconInfo {
   pub data: String,

--- a/x-win-rs/src/common/x_win_struct/process_info.rs
+++ b/x-win-rs/src/common/x_win_struct/process_info.rs
@@ -3,7 +3,7 @@
 /**
  * Struct to store process information of the window
  */
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, PartialOrd)]
 #[repr(C)]
 pub struct ProcessInfo {
   pub process_id: u32,

--- a/x-win-rs/src/common/x_win_struct/usage_info.rs
+++ b/x-win-rs/src/common/x_win_struct/usage_info.rs
@@ -3,7 +3,7 @@
 /**
  * Struct to store usage data of the window
  */
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, PartialOrd)]
 pub struct UsageInfo {
   pub memory: u32,
 }

--- a/x-win-rs/src/common/x_win_struct/window_info.rs
+++ b/x-win-rs/src/common/x_win_struct/window_info.rs
@@ -5,7 +5,7 @@ use super::{process_info::ProcessInfo, usage_info::UsageInfo, window_position::W
 /**
  * Struct to store all informations of the window
  */
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, PartialOrd)]
 pub struct WindowInfo {
   pub id: u32,
   pub os: String,

--- a/x-win-rs/src/common/x_win_struct/window_position.rs
+++ b/x-win-rs/src/common/x_win_struct/window_position.rs
@@ -3,7 +3,7 @@
 /**
  * Struct to store position and size of the window
  */
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, PartialOrd)]
 pub struct WindowPosition {
   pub x: i32,
   pub y: i32,

--- a/x-win-rs/src/linux/api.rs
+++ b/x-win-rs/src/linux/api.rs
@@ -94,7 +94,7 @@ impl APIGnome for LinuxAPI {
 
   fn is_installed_extension() -> Result<bool> {
     if is_wayland_desktop() {
-      WaylandApi::disable_extension()
+      WaylandApi::is_installed_extension()
     } else {
       Ok(false)
     }

--- a/x-win-rs/src/linux/api/gnome_shell.rs
+++ b/x-win-rs/src/linux/api/gnome_shell.rs
@@ -410,8 +410,8 @@ pub fn value_to_icon_info(response: &serde_json::Value) -> Result<IconInfo, &'st
 
   Ok(IconInfo {
     data: str_to_string(response, "data"),
-    height: number_to_u32(&response, "height"),
-    width: number_to_u32(&response, "width"),
+    height: number_to_u32(response, "height"),
+    width: number_to_u32(response, "width"),
   })
 }
 

--- a/x-win-rs/src/linux/api/gnome_shell.rs
+++ b/x-win-rs/src/linux/api/gnome_shell.rs
@@ -149,6 +149,7 @@ function _strcut_data(window_actor) {
         process_id: 0,
         path: '',
         exec_name: '',
+        name: '',
       },
       position: {
         width: 0,
@@ -276,6 +277,7 @@ function _strcut_data(window_actor) {
         process_id: 0,
         path: '',
         exec_name: '',
+        name: '',
       },
       position: {
         width: 0,

--- a/x-win-rs/src/linux/api/gnome_shell.rs
+++ b/x-win-rs/src/linux/api/gnome_shell.rs
@@ -385,21 +385,33 @@ export default class XWinWaylandExtension extends Extension {
 }
 "#;
 
-pub fn number_to_u32(value: &serde_json::Value) -> u32 {
-  value.as_u64().map(|v| v as u32).unwrap_or(0)
+fn number_to_u32(value: &serde_json::Map<String, serde_json::Value>, key: &str) -> u32 {
+  value_to_i64(value, key) as u32
 }
 
-pub fn number_to_i32(value: &serde_json::Value) -> i32 {
-  value.as_i64().map(|v| v as i32).unwrap_or(0)
+fn number_to_i32(value: &serde_json::Map<String, serde_json::Value>, key: &str) -> i32 {
+  value_to_i64(value, key) as i32
+}
+
+fn value_to_i64(value: &serde_json::Map<String, serde_json::Value>, key: &str) -> i64 {
+  value.get(key).and_then(|v| v.as_i64()).unwrap_or(0)
+}
+
+fn str_to_string(value: &serde_json::Map<String, serde_json::Value>, key: &str) -> String {
+  value
+    .get(key)
+    .and_then(|v| v.as_str())
+    .unwrap_or("")
+    .to_string()
 }
 
 pub fn value_to_icon_info(response: &serde_json::Value) -> Result<IconInfo, &'static str> {
   let response = response.as_object().ok_or("Expected JSON object")?;
 
   Ok(IconInfo {
-    data: response["data"].as_str().unwrap_or("").to_string(),
-    height: number_to_u32(&response["height"]),
-    width: number_to_u32(&response["width"]),
+    data: str_to_string(response, "data"),
+    height: number_to_u32(&response, "height"),
+    width: number_to_u32(&response, "width"),
   })
 }
 
@@ -414,24 +426,27 @@ pub fn value_to_window_info(response: &serde_json::Value) -> Result<WindowInfo, 
     .ok_or("Expected JSON object")?;
 
   Ok(WindowInfo {
-    id: number_to_u32(&response["id"]),
-    os: response["os"].as_str().unwrap_or("linux").to_string(),
-    title: response["title"].as_str().unwrap_or("").to_string(),
+    id: number_to_u32(response, "id"),
+    os: str_to_string(response, "os"),
+    title: str_to_string(response, "title"),
     position: WindowPosition {
-      height: number_to_i32(&position["height"]),
-      width: number_to_i32(&position["width"]),
-      x: number_to_i32(&position["x"]),
-      y: number_to_i32(&position["y"]),
-      is_full_screen: position["isFullScreen"].as_bool().unwrap_or(false),
+      height: number_to_i32(position, "height"),
+      width: number_to_i32(position, "width"),
+      x: number_to_i32(position, "x"),
+      y: number_to_i32(position, "y"),
+      is_full_screen: position
+        .get("isFullScreen")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false),
     },
     info: ProcessInfo {
-      exec_name: info["exec_name"].as_str().unwrap_or("").to_string(),
-      name: info["name"].as_str().unwrap_or("").to_string(),
-      path: info["path"].as_str().unwrap_or("").to_string(),
-      process_id: number_to_u32(&info["process_id"]),
+      exec_name: str_to_string(info, "exec_name"),
+      name: str_to_string(info, "name"),
+      path: str_to_string(info, "path"),
+      process_id: number_to_u32(info, "process_id"),
     },
     usage: UsageInfo {
-      memory: number_to_u32(&usage["memory"]),
+      memory: number_to_u32(usage, "memory"),
     },
   })
 }
@@ -454,3 +469,312 @@ impl GnomeVersion {
 
 pub static GNOME_SINGLETON: Lazy<Mutex<GnomeVersion>> =
   Lazy::new(|| Mutex::new(GnomeVersion::new()));
+
+#[cfg(test)]
+mod tests {
+  use crate::common::x_win_struct::{
+    icon_info::IconInfo, process_info::ProcessInfo, usage_info::UsageInfo, window_info::WindowInfo,
+    window_position::WindowPosition,
+  };
+  use crate::linux::api::gnome_shell::{
+    number_to_i32, number_to_u32, str_to_string, value_to_icon_info, value_to_window_info,
+  };
+
+  /**
+   * Test str_to_string function
+   */
+  #[test]
+  fn test_str_to_string() -> Result<(), Box<dyn std::error::Error>> {
+    let title = {
+      let value: serde_json::Value = serde_json::from_str("{}")?;
+      let value = value.as_object().ok_or("failed to test")?;
+      str_to_string(value, "title")
+    };
+
+    assert_eq!(title, "");
+
+    let title = {
+      let value: serde_json::Value = serde_json::from_str("{\"title\":\"\"}")?;
+      let value = value.as_object().ok_or("failed to test")?;
+      str_to_string(value, "title")
+    };
+    assert_eq!(title, "");
+
+    let title = {
+      let value: serde_json::Value = serde_json::from_str("{\"title\":\"test\"}")?;
+      let value = value.as_object().ok_or("failed to test")?;
+      str_to_string(value, "title")
+    };
+    assert_eq!(title, "test");
+
+    Ok(())
+  }
+
+  /**
+   * Test number_to_u32 function
+   */
+  #[test]
+  fn test_number_to_u32() -> Result<(), Box<dyn std::error::Error>> {
+    let width = {
+      let value: serde_json::Value = serde_json::from_str("{}")?;
+      let value = value.as_object().ok_or("failed to test")?;
+      number_to_u32(value, "width")
+    };
+
+    assert_eq!(width, 0);
+
+    let width = {
+      let value: serde_json::Value = serde_json::from_str("{\"width\":\"\"}")?;
+      let value = value.as_object().ok_or("failed to test")?;
+      number_to_u32(value, "width")
+    };
+    assert_eq!(width, 0);
+
+    let width = {
+      let value: serde_json::Value = serde_json::from_str("{\"width\":\"test\"}")?;
+      let value = value.as_object().ok_or("failed to test")?;
+      number_to_u32(value, "width")
+    };
+    assert_eq!(width, 0);
+
+    let width = {
+      let value: serde_json::Value = serde_json::from_str("{\"width\":0}")?;
+      let value = value.as_object().ok_or("failed to test")?;
+      number_to_u32(value, "width")
+    };
+    assert_eq!(width, 0);
+
+    let width = {
+      let value: serde_json::Value = serde_json::from_str("{\"width\":0.0}")?;
+      let value = value.as_object().ok_or("failed to test")?;
+      number_to_u32(value, "width")
+    };
+    assert_eq!(width, 0);
+
+    let width = {
+      let value: serde_json::Value = serde_json::from_str("{\"width\":1000}")?;
+      let value = value.as_object().ok_or("failed to test")?;
+      number_to_u32(value, "width")
+    };
+    assert_eq!(width, 1000);
+
+    let width = {
+      let value: serde_json::Value = serde_json::from_str("{\"width\":\"1000\"}")?;
+      let value = value.as_object().ok_or("failed to test")?;
+      number_to_u32(value, "width")
+    };
+    assert_eq!(width, 0);
+
+    Ok(())
+  }
+
+  /**
+   * Test number_to_i32 function
+   */
+  #[test]
+  fn test_number_to_i32() -> Result<(), Box<dyn std::error::Error>> {
+    let width = {
+      let value: serde_json::Value = serde_json::from_str("{}")?;
+      let value = value.as_object().ok_or("failed to test")?;
+      number_to_i32(value, "width")
+    };
+
+    assert_eq!(width, 0);
+
+    let width = {
+      let value: serde_json::Value = serde_json::from_str("{\"width\":\"\"}")?;
+      let value = value.as_object().ok_or("failed to test")?;
+      number_to_i32(value, "width")
+    };
+    assert_eq!(width, 0);
+
+    let width = {
+      let value: serde_json::Value = serde_json::from_str("{\"width\":\"test\"}")?;
+      let value = value.as_object().ok_or("failed to test")?;
+      number_to_i32(value, "width")
+    };
+    assert_eq!(width, 0);
+
+    let width = {
+      let value: serde_json::Value = serde_json::from_str("{\"width\":0}")?;
+      let value = value.as_object().ok_or("failed to test")?;
+      number_to_i32(value, "width")
+    };
+    assert_eq!(width, 0);
+
+    let width = {
+      let value: serde_json::Value = serde_json::from_str("{\"width\":0.0}")?;
+      let value = value.as_object().ok_or("failed to test")?;
+      number_to_i32(value, "width")
+    };
+    assert_eq!(width, 0);
+
+    let width = {
+      let value: serde_json::Value = serde_json::from_str("{\"width\":1000}")?;
+      let value = value.as_object().ok_or("failed to test")?;
+      number_to_i32(value, "width")
+    };
+    assert_eq!(width, 1000);
+
+    let width = {
+      let value: serde_json::Value = serde_json::from_str("{\"width\":\"1000\"}")?;
+      let value = value.as_object().ok_or("failed to test")?;
+      number_to_i32(value, "width")
+    };
+    assert_eq!(width, 0);
+
+    Ok(())
+  }
+
+  /**
+   * Test value_to_icon_info function
+   */
+  #[test]
+  fn test_value_to_icon_info() -> Result<(), Box<dyn std::error::Error>> {
+    let icon_info = {
+      let value: serde_json::Value = serde_json::from_str("{}")?;
+      value_to_icon_info(&value)?
+    };
+
+    assert_eq!(
+      icon_info,
+      IconInfo {
+        data: String::from(""),
+        height: 0,
+        width: 0,
+      }
+    );
+
+    let icon_info = {
+      let value: serde_json::Value =
+        serde_json::from_str("{\"data\": \"test\", \"width\": 100, \"height\": 200}")?;
+      value_to_icon_info(&value)?
+    };
+
+    assert_eq!(
+      icon_info,
+      IconInfo {
+        data: String::from("test"),
+        height: 200,
+        width: 100,
+      }
+    );
+
+    let icon_info = {
+      let value: serde_json::Value = serde_json::from_str("{\"width\": 100, \"height\": 200}")?;
+      value_to_icon_info(&value)?
+    };
+
+    assert_eq!(
+      icon_info,
+      IconInfo {
+        data: String::from(""),
+        height: 200,
+        width: 100,
+      }
+    );
+
+    let icon_info = {
+      let value: serde_json::Value = serde_json::from_str("{\"data\": \"test\", \"height\": 200}")?;
+      value_to_icon_info(&value)?
+    };
+
+    assert_eq!(
+      icon_info,
+      IconInfo {
+        data: String::from("test"),
+        height: 200,
+        width: 0,
+      }
+    );
+
+    let icon_info = {
+      let value: serde_json::Value = serde_json::from_str("{\"data\": \"test\", \"width\": 100}")?;
+      value_to_icon_info(&value)?
+    };
+
+    assert_eq!(
+      icon_info,
+      IconInfo {
+        data: String::from("test"),
+        height: 0,
+        width: 100,
+      }
+    );
+
+    Ok(())
+  }
+
+  /**
+   * Test value_to_window_info function
+   */
+  #[test]
+  fn test_value_to_window_info() -> Result<(), Box<dyn std::error::Error>> {
+    // Test total blank values
+    let window_info = {
+      let value: serde_json::Value = serde_json::from_str(
+        r#"{"id":0,"os":"","info":{"process_id":0,"name":"","path":"","exec_name":""},"title":"","position":{"width":0,"height":0,"x":0,"y":0,"isFullScreen":false},"usage":{"memory":0}}"#,
+      )?;
+      value_to_window_info(&value)?
+    };
+
+    assert_eq!(
+      window_info,
+      WindowInfo::new(
+        0,
+        String::from(""),
+        String::from(""),
+        WindowPosition::new(0, 0, 0, 0, false),
+        ProcessInfo::new(0, String::from(""), String::from(""), String::from("")),
+        UsageInfo::new(0)
+      )
+    );
+
+    // Test without name attribute
+    let window_info = {
+      let value: serde_json::Value = serde_json::from_str(
+        r#"{"id":0,"os":"","info":{"process_id":0,"path":"","exec_name":""},"title":"","position":{"width":0,"height":0,"x":0,"y":0,"isFullScreen":false},"usage":{"memory":0}}"#,
+      )?;
+      value_to_window_info(&value)?
+    };
+
+    assert_eq!(
+      window_info,
+      WindowInfo::new(
+        0,
+        String::from(""),
+        String::from(""),
+        WindowPosition::new(0, 0, 0, 0, false),
+        ProcessInfo::new(0, String::from(""), String::from(""), String::from("")),
+        UsageInfo::new(0)
+      )
+    );
+
+    // Test without name attribute
+    let window_info = {
+      let value: serde_json::Value = serde_json::from_str(
+        r#"{"id":3038270935,"os":"linux","info":{"process_id":95389,"name":"gnome-terminal-server","path":"/usr/libexec/gnome-terminal-server","exec_name":"gnome-terminal-server"},"title":"new terminal","position":{"width":866,"height":629,"x":1077,"y":192,"isFullScreen":true},"usage":{"memory":139473}}"#,
+      )?;
+      value_to_window_info(&value)?
+    };
+
+    assert_eq!(
+      window_info,
+      WindowInfo::new(
+        3038270935,
+        String::from("linux"),
+        String::from("new terminal"),
+        WindowPosition::new(1077, 192, 866, 629, true),
+        ProcessInfo::new(
+          95389,
+          String::from("/usr/libexec/gnome-terminal-server"),
+          String::from("gnome-terminal-server"),
+          String::from("gnome-terminal-server")
+        ),
+        UsageInfo::new(139473)
+      )
+    );
+
+    Ok(())
+  }
+}

--- a/x-win-rs/src/linux/api/wayland_extension_api.rs
+++ b/x-win-rs/src/linux/api/wayland_extension_api.rs
@@ -194,23 +194,19 @@ pub fn is_enabled_extension() -> Result<bool> {
   if !body.is_empty() {
     let response: HashMap<String, OwnedValue> = body.deserialize()?;
     if !response.is_empty() {
-      let enabled = response
-        .get("enabled")
-        .and_then(|v| {
-          println!("test: {:?}", v);
-          v.downcast_ref::<bool>().ok()
-        })
-        .unwrap_or(false);
-      if !enabled {
-        // Fallback for gnome between 42 and 44
-        let state = response
-          .get("state")
-          .and_then(|v| v.downcast_ref::<f64>().ok())
-          .unwrap_or(0.0);
-        return Ok(state.eq(&1.0));
-      } else {
-        return Ok(true);
+      let state = response
+        .get("state")
+        .and_then(|v| v.downcast_ref::<f64>().ok())
+        .unwrap_or(0.0);
+      // State 3 = Error
+      if state.eq(&3.0) {
+        return Err(
+    format!(
+      r#""{GNOME_XWIN_UUID}" extension is installed but does not work correctly. Please check your journalctl to find the error."#
+    ).into()
+  );
       }
+      return Ok(state.eq(&1.0));
     }
   }
 
@@ -227,11 +223,19 @@ pub fn is_installed_extension() -> Result<bool> {
   if !body.is_empty() {
     let response: HashMap<String, OwnedValue> = body.deserialize()?;
     if !response.is_empty() {
-      let uuid = response
-        .get("uuid")
-        .and_then(|v| v.downcast_ref::<String>().ok())
-        .unwrap_or_default();
-      return Ok(GNOME_XWIN_UUID.eq(&uuid));
+      let state = response
+        .get("state")
+        .and_then(|v| v.downcast_ref::<f64>().ok())
+        .unwrap_or(0.0);
+      // State 3 = Error
+      if state.eq(&3.0) {
+        return Err(
+    format!(
+      r#""{GNOME_XWIN_UUID}" extension is installed but does not work correctly. Please check your journalctl to find the error."#
+    ).into()
+  );
+      }
+      return Ok(state.ne(&0.0));
     }
   }
   Ok(false)

--- a/x-win-rs/src/linux/api/wayland_extension_api.rs
+++ b/x-win-rs/src/linux/api/wayland_extension_api.rs
@@ -1,6 +1,6 @@
-use zbus::{blocking::Connection, Message};
+use zbus::{blocking::Connection, zvariant::OwnedValue, Message};
 
-use std::{env, fs, ops::Deref, path};
+use std::{collections::HashMap, env, fs, ops::Deref, path};
 
 use crate::{
   common::{
@@ -190,14 +190,26 @@ pub fn uninstall_extension() -> Result<bool> {
 
 pub fn is_enabled_extension() -> Result<bool> {
   let response = request_extension_info()?;
-  let response: String = response.body().deserialize().unwrap_or_default();
-  if !response.is_empty() {
-    let response: serde_json::Value = serde_json::from_str(response.as_str())?;
-    if response.is_object() {
-      let response = response.as_object().ok_or("Expected JSON object")?;
-      if response.contains_key("enabled") {
-        let response = response["enabled"].as_bool().unwrap_or(false);
-        return Ok(response);
+  let body = response.body();
+  if !body.is_empty() {
+    let response: HashMap<String, OwnedValue> = body.deserialize()?;
+    if !response.is_empty() {
+      let enabled = response
+        .get("enabled")
+        .and_then(|v| {
+          println!("test: {:?}", v);
+          v.downcast_ref::<bool>().ok()
+        })
+        .unwrap_or(false);
+      if !enabled {
+        // Fallback for gnome between 42 and 44
+        let state = response
+          .get("state")
+          .and_then(|v| v.downcast_ref::<f64>().ok())
+          .unwrap_or(0.0);
+        return Ok(state.eq(&1.0));
+      } else {
+        return Ok(true);
       }
     }
   }
@@ -210,11 +222,16 @@ pub fn is_enabled_extension() -> Result<bool> {
 }
 
 pub fn is_installed_extension() -> Result<bool> {
-  let response = request_extension_info();
-  if let Ok(response) = response {
-    let response: String = response.body().deserialize().unwrap_or_default();
+  let response = request_extension_info()?;
+  let body = response.body();
+  if !body.is_empty() {
+    let response: HashMap<String, OwnedValue> = body.deserialize()?;
     if !response.is_empty() {
-      return Ok(true);
+      let uuid = response
+        .get("uuid")
+        .and_then(|v| v.downcast_ref::<String>().ok())
+        .unwrap_or_default();
+      return Ok(GNOME_XWIN_UUID.eq(&uuid));
     }
   }
   Ok(false)


### PR DESCRIPTION
## Fix Issues
* Fix issue #89 with wrong function used to for is_installed_extension when using wayland api
* Fix issue #90 to handle correctly the value from `getExtensionInfo` method
* Fix issue #91 Add missing attribute for empty window information + rework data