### PR TITLE
fix(x11): Replace from_utf8_unchecked with from_utf8_lossy Issue #98

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,12 @@ crate-type = ["cdylib"]
 [dependencies]
 # Default enable napi4 feature, see https://nodejs.org/api/n-api.html#node-api-version-matrix
 base64 = "0.22.1"
-napi = { version = "3.9.4", default-features = false, features = [
+napi = { version = "3.10.5", default-features = false, features = [
   "napi4",
   "async",
   "compat-mode",
 ] }
-napi-derive = "3.5.7"
+napi-derive = "3.5.10"
 once_cell = "1.21.4"
 x-win = { path = "./x-win-rs" }
 

--- a/x-win-rs/Cargo.toml
+++ b/x-win-rs/Cargo.toml
@@ -48,7 +48,7 @@ image      = "0.25.10"
 serde_json = { version = "1.0.150" }
 x11        = { version = "2.21.0", features = ["xlib"], optional = true }
 xcb        = { version = "1.7.0" }
-zbus       = { version = "5.16.0" }
+zbus       = { version = "5.17.0" }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 block2 = "0.6.2"

--- a/x-win-rs/src/linux/api/x11_api.rs
+++ b/x-win-rs/src/linux/api/x11_api.rs
@@ -263,7 +263,11 @@ fn get_window_position(conn: &xcb::Connection, window: x::Window) -> WindowPosit
  * Get window title
  */
 fn get_window_title(conn: &xcb::Connection, window: x::Window) -> String {
-  _get_string_response(conn, window, x::ATOM_WM_NAME)
+  let mut title = _get_string_response(conn, window, x::ATOM_WM_NAME);
+  if title.is_empty() {
+    title = _get_string_response(conn, window, x::ATOM_WM_NAME);
+  }
+  title
 }
 
 fn _get_string_response(conn: &xcb::Connection, window: x::Window, property: x::Atom) -> String {
@@ -277,7 +281,7 @@ fn _get_string_response(conn: &xcb::Connection, window: x::Window, property: x::
   });
   if let Ok(window_title) = conn.wait_for_reply(window_title) {
     let window_title: &[u8] = window_title.value();
-    unsafe { std::str::from_utf8_unchecked(window_title).to_string() }
+    String::from_utf8_lossy(window_title).to_string()
   } else {
     String::from("")
   }

--- a/x-win-rs/src/linux/api/x11_api.rs
+++ b/x-win-rs/src/linux/api/x11_api.rs
@@ -263,7 +263,14 @@ fn get_window_position(conn: &xcb::Connection, window: x::Window) -> WindowPosit
  * Get window title
  */
 fn get_window_title(conn: &xcb::Connection, window: x::Window) -> String {
-  let mut title = _get_string_response(conn, window, x::ATOM_WM_NAME);
+  let mut title: String = {
+    let atom_net_wm_name = get_atom(conn, b"_NET_WM_NAME", true);
+    if !atom_net_wm_name.is_none() {
+      _get_string_response(conn, window, atom_net_wm_name)
+    } else {
+      String::from("")
+    }
+  };
   if title.is_empty() {
     title = _get_string_response(conn, window, x::ATOM_WM_NAME);
   }


### PR DESCRIPTION
## Issue #98 
Problem with none UTF-8 characters who crash with `from_utf8_unchecked`.
Refs:
* [xcb issue 96](https://github.com/rust-x-bindings/rust-xcb/issues/96#issuecomment-1001213253)
* [win-pos-rs issue 27](https://github.com/dimusic/active-win-pos-rs/pull/27#issue-2012956136)

Add a fallback if no result using `ATOM_NET_WM_NAME`
